### PR TITLE
Convert to the new Migen API, add Spartan 3A support

### DIFF
--- a/bscan_spi.py
+++ b/bscan_spi.py
@@ -1,7 +1,6 @@
 # Robert Jordens <jordens@gmail.com> 2015
 
-from migen.fhdl.std import *
-from migen.genlib.record import *
+from migen import *
 
 
 bscan_layout = [

--- a/xilinx.py
+++ b/xilinx.py
@@ -56,7 +56,7 @@ class Series7(Module):
 def build_bscan_spi(platform, Top):
     name = "bscan_spi_{}".format(platform.device)
     top = Top(platform)
-    platform.build_cmdline(top, build_name=name)
+    platform.build(top, build_name=name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Self-explanatory. This quick change makes it possible to use Migen to generate proxy bitstreams for `xc3sprog` for the time being, and enables use of the current API.
